### PR TITLE
fix: fix compile error in newer compilers

### DIFF
--- a/Sources/UniYAML/YAML.swift
+++ b/Sources/UniYAML/YAML.swift
@@ -33,7 +33,7 @@ public enum YAMLType: String {
 public struct YAML {
 	let indent: Int
 	var type: YAMLType
-	let key: String?
+	var key: String?
 	let tag: String?
 	var value: Any?
 	public var count: Int? {


### PR DESCRIPTION
I fixed the following error:

```
Sources/UniYAML/YAML.swift:218:12: error: cannot assign to property: 'key' is a 'let' constant
 34 | 	let indent: Int
 35 | 	var type: YAMLType
 36 | 	let key: String?
    |  `- note: change 'let' to 'var' to make it mutable
 37 | 	let tag: String?
 38 | 	var value: Any?
    :
216 | 				return nil
217 | 			}
218 | 			obj[k]!.key = k
    |            `- error: cannot assign to property: 'key' is a 'let' constant
219 | 		}
220 | 		indent = 0
```

This error has occurred since Swift 6.1.